### PR TITLE
Shorten file name to fix issue when using watch command

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = (env) => ({
   },
   output: {
     filename: '[name].bundle.js',
-    chunkFilename: '[name].[chunkhash:5].bundle.js',
+    chunkFilename: '[chunkhash:5].bundle.js',
     path: path.resolve(__dirname, 'theme/assets'),
   },
   optimization: {


### PR DESCRIPTION
This change fixes the issue with the cart modal not working when running watch commands. Thanks to @lnehlsen for finding this solution.

#9 